### PR TITLE
post(swrv) repair broken link

### DIFF
--- a/docs/_posts/data-fetching-vue-composition-api.md
+++ b/docs/_posts/data-fetching-vue-composition-api.md
@@ -291,7 +291,7 @@ states, different caching strategies, polling, onFocus revalidation etc.
 
 ## SWRV
 
-[swrv](pronounced 'swerve') is a library using
+[swrv] (pronounced 'swerve') is a library using
 [@vue/composition-api](https://github.com/vuejs/composition-api) hooks for
 remote data fetching. It is largely a port of
 [swr](https://github.com/zeit/swr). Our example can be refactored:


### PR DESCRIPTION
thanks for this interesting blogpost. I noticed a small error in a link generation.
(I assume you didn't wanted to generate this link: https://guuu.io/2020/data-fetching-vue-composition-api/pronounced)